### PR TITLE
Moto/lamu: fix requiredSystemPropertyName

### DIFF
--- a/Moto/lamu/AndroidManifest.xml
+++ b/Moto/lamu/AndroidManifest.xml
@@ -3,8 +3,8 @@
         android:versionCode="1"
         android:versionName="1.0">
         <overlay android:targetPackage="android"
-                 android:requiredSystemPropertyName="ro.product.vendor.device"
-                 android:requiredSystemPropertyValue="+*lamu*"
+                 android:requiredSystemPropertyName="ro.product.device"
+                 android:requiredSystemPropertyValue="lamu"
         android:priority="797"
         android:isStatic="true" />
 </manifest>


### PR DESCRIPTION
Overlay was not activating.